### PR TITLE
Update colorpicker.js to avoid discrepancies with the controlColor2

### DIFF
--- a/dist/colorpicker.js
+++ b/dist/colorpicker.js
@@ -7536,6 +7536,7 @@ var ColorControl$2 = function (_UIElement) {
         value: function refresh() {
             this.setColorUI();
             this.setBackgroundColor();
+	    this.setLastUpdateColor();
         }
     }, {
         key: 'setColorUI',


### PR DESCRIPTION
There is a bug in the `chromedeveltool` type ColorPicker with the 2 color controls preview, where if you try to update the current color externally through colorPicker.initColor() it only updates the first color control preview `$controlColor` and not the second color control preview `$controlColor2`. I added an external eye dropper and encountered the issue shown in the attached screenshot below.

<img width="225" alt="Screenshot 2025-05-27 at 6 33 51 PM" src="https://github.com/user-attachments/assets/8014b39c-9cab-4f8b-9b0e-afd7e572a5bf" />

